### PR TITLE
Improve handling of media type escaping according to RFC 723x

### DIFF
--- a/httpheader.py
+++ b/httpheader.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
+from __future__ import print_function
 """ Utility functions to work with HTTP headers.
 
  This module provides some utility functions useful for parsing
@@ -496,10 +497,9 @@ def _test_comments():
     def _testrm( a, b, collapse ):
         b2 = remove_comments( a, collapse )
         if b != b2:
-            print 'Comment test failed:'
-            print '   remove_comments( %s, collapse_spaces=%s ) -> %s' \
-                  % (repr(a), repr(collapse), repr(b2))
-            print '   expected %s' % repr(b)
+            print('Comment test failed:')
+            print('   remove_comments( {0}, collapse_spaces={1} ) -> {2}'.format(repr(a), repr(collapse), repr(b2)))
+            print('   expected {0}'.format(repr(b)))
             return 1
         return 0
     failures = 0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from distutils.core import setup
 name = "httpheader"
-version = "1.1"
+version = "1.2"
 setup( name=name,
        version=version,
        py_modules=[name],


### PR DESCRIPTION
According to [Section 3.2.3](http://greenbytes.de/tech/webdav/draft-ietf-httpbis-p1-messaging-16.html#field.rules):

> Senders SHOULD NOT escape octets in quoted-strings that do not require escaping (i.e., other than DQUOTE and the backslash octet).

However, currently quote_string() escapes SEPARATOR characters that does not need to be escaped:

```
>>> print quote_string('test/one two\\ @three')
"test\/one\ two\\\ \@three"
```

They rather should be:

```
>>> print quote_string('test/one two\\ @three')
"test/one two\\ @three"
```
